### PR TITLE
Stop main game panel from scrolling.

### DIFF
--- a/webAO/client.html
+++ b/webAO/client.html
@@ -102,18 +102,18 @@
 				<div id="client_trackstatus" style="display: none;"><p id="client_trackstatustext">None</p></div>
 			</div>
 		</div>
+		<input id="client_inputbox" class="long" type="text" onkeypress="onEnter(event)"
+			placeholder="Say something&hellip;" autocomplete="off">
+		<div id="client_bars">
+			<span id="client_defense_hp" class="health-box">
+				<div class="health-bar"></div>
+			</span>
+			<span id="client_prosecutor_hp" class="health-box">
+				<div class="health-bar"></div>
+			</span>
+		</div>
 		<div id="client_iccontrols">
-			<input id="client_inputbox" class="long" type="text" onkeypress="onEnter(event)"
-				placeholder="Say something&hellip;" autocomplete="off">
 			<meta name="frame-title" lang="en" content="miscellaneous">
-			<div id="client_bars">
-				<span id="client_defense_hp" class="health-box">
-					<div class="health-bar"></div>
-				</span>
-				<span id="client_prosecutor_hp" class="health-box">
-					<div class="health-bar"></div>
-				</span>
-			</div>
 			<div id="client_emo">
 			</div>
 			<br>

--- a/webAO/styles/client.css
+++ b/webAO/styles/client.css
@@ -121,6 +121,10 @@
 	height: 100%;
 }
 
+#client_iccontrols {
+	overflow-y:auto;
+}
+
 @keyframes shake {
 
 	0%,

--- a/webAO/styles/client.css
+++ b/webAO/styles/client.css
@@ -115,8 +115,9 @@
 }
 
 #client_icwrapper {
-	overflow-x: hidden;
-	overflow-y: auto;
+	overflow: hidden;
+	display:flex;
+	flex-flow: column nowrap;
 	height: 100%;
 }
 


### PR DESCRIPTION
This PR makes the client_icwrapper a non-scrollable columnated flexbox, fixing the game-window in place. Aswell, It detaches the game bars and text input from client_iccontrols so that they, too, are not affected by scroll. The client_iccontrols panel has been allowed to scroll, so that all of its utility can still be accessed, but without moving the main game panel, bars, and text input.