### PR TITLE
Fix OOC horizontal scrolling from typing too much in the input box.

### DIFF
--- a/webAO/client.html
+++ b/webAO/client.html
@@ -506,9 +506,9 @@
 	<meta name="frame-title" lang="en" content="Server">
 	<div style="height: 100%; display: flex; flex-direction: column;">
 		<textarea id="client_ooclog" style="flex: 1 auto" readonly></textarea>
-		<span id="client_oocinput" style="display: inline-block; white-space: nowrap;">
-			<input id="OOC_name" style="width: 15%;" name="OOC_name" type="text">
-			<input id="client_oocinputbox" style="width: 85%;" type="text" onkeypress="onOOCEnter(event)">
+		<span id="client_oocinput">
+			<input id="OOC_name" name="OOC_name" type="text">
+			<input id="client_oocinputbox" type="text" onkeypress="onOOCEnter(event)">
 		</span>
 		<span id="client_replaycontrols" style="display: none; white-space: nowrap;">
 			<input id="client_replaygo" style="width: 25%;" type="button" onclick="onReplayGo(event)" value="GO">

--- a/webAO/styles/client.css
+++ b/webAO/styles/client.css
@@ -125,6 +125,7 @@
 	overflow-y:auto;
 }
 
+
 @keyframes shake {
 
 	0%,
@@ -447,6 +448,20 @@
 	resize: none;
 	flex: 1 1 auto;
 	border: none;
+}
+
+#client_oocinput {
+	display:flex;
+	flex-flow: row nowrap;
+	whitespace: nowrap;	
+}
+
+#client_oocinputbox {
+	flex-grow:1;
+}
+
+#OOC_name {
+	width:15%;	
 }
 
 #client_musicsearch {


### PR DESCRIPTION
Title explains it well. Turns client_oocinput into a flexbox, removes the fixed size from client_oocinputbox and replaces it with flex-grow:1
Prevents the OOC log from overflowing in a way that's impossible to fix.