### PR TITLE
Don't Double Display Character Select

### DIFF
--- a/webAO/client.js
+++ b/webAO/client.js
@@ -1218,8 +1218,6 @@ class Client extends EventEmitter {
     document.getElementById('client_loading').style.display = 'none';
     if (mode === 'watch') {		// Spectators don't need to pick a character
       document.getElementById('client_charselect').style.display = 'none';
-    } else {
-      document.getElementById('client_charselect').style.display = 'block';
     }
   }
 


### PR DESCRIPTION
If a user is quick, and selects a character, before the packet was sent, the charselect will appear again. 