### PR TITLE
Adding blip sounds to actual audio tags

### DIFF
--- a/webAO/client.js
+++ b/webAO/client.js
@@ -1674,15 +1674,8 @@ class Viewport {
     ];
 
     // Allocate multiple blip audio channels to make blips less jittery
-
-    this.blipChannels = new Array(
-      new Audio(`${AO_HOST}sounds/general/sfx-blipmale.opus`),
-      new Audio(`${AO_HOST}sounds/general/sfx-blipmale.opus`),
-      new Audio(`${AO_HOST}sounds/general/sfx-blipmale.opus`),
-      new Audio(`${AO_HOST}sounds/general/sfx-blipmale.opus`),
-      new Audio(`${AO_HOST}sounds/general/sfx-blipmale.opus`),
-      new Audio(`${AO_HOST}sounds/general/sfx-blipmale.opus`),
-    );
+    const blipSelectors = document.getElementsByClassName('blipSound')
+    this.blipChannels = [...blipSelectors];
     this.blipChannels.forEach((channel) => channel.volume = 0.5);
     this.blipChannels.forEach((channel) => channel.onerror = opusCheck(channel));
     this.currentBlipChannel = 0;

--- a/webAO/client/aoHost.js
+++ b/webAO/client/aoHost.js
@@ -1,0 +1,5 @@
+import queryParser from '../utils/queryParser'
+let { asset } = queryParser();
+const DEFAULT_HOST = 'http://attorneyoffline.de/base/';
+const AO_HOST = asset || DEFAULT_HOST 
+export default AO_HOST

--- a/webAO/components/__tests__/blips.test.js
+++ b/webAO/components/__tests__/blips.test.js
@@ -1,0 +1,9 @@
+import createBlip from "../blip";
+
+describe('createBlip', () => {
+    test('create 3 blips audios', () => {
+        document.body.innerHTML = ``
+        createBlip(3)
+        expect(document.getElementsByClassName('blipSound').length).toBe(3)
+    })
+})

--- a/webAO/components/blip.js
+++ b/webAO/components/blip.js
@@ -1,0 +1,17 @@
+import AO_HOST from '../client/aoHost'
+
+/**
+ * 
+ * @param {number} amountOfBlips Amount of Blips to put on page
+ */
+const createBlip = (amountOfBlips) => {
+    for (let i = 0; i < amountOfBlips; i++) {
+        const audio = document.createElement('audio')
+        const blipUrl = `${AO_HOST}sounds/general/sfx-blipmale.opus`
+        audio.setAttribute('class', 'blipSound')
+        audio.setAttribute('src', blipUrl)
+        document.body.appendChild(audio)
+    }
+}
+createBlip(3)
+export default createBlip

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
     client: './webAO/client.js',
     master: './webAO/master.js',
     dom: glob.sync('./webAO/dom/*.js'),
+    components: glob.sync('./webAO/components/*.js'),
   },
   node: {
     global: true,
@@ -86,7 +87,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       title: 'Attorney Online',
       filename: 'client.html',
-      chunks: ['client', 'ui', 'dom'],
+      chunks: ['client', 'ui', 'dom', 'components'],
       template: 'public/client.html',
     }),
     new webpack.DefinePlugin({


### PR DESCRIPTION
This is a PR to work with #116 so we can maintain [feature parity](https://trello.com/c/RO2VOlVo/16-custom-audio-device-selection) with 2.6. 
By removing the `new Audio()` and replacing them with `<audio>` tags, I have the ability to query the document for those.
This also adds a bonus of having them pre-rendered on the initial load.