### PR TITLE
Full Strict Typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist",
     "allowJs": true,
     "target": "es5",
-    //"strict": true,
+    "strict": true,
     "strictNullChecks": false, //document.getElementBy
     "downlevelIteration": true
   },

--- a/webAO/utils/aoml.ts
+++ b/webAO/utils/aoml.ts
@@ -1,6 +1,7 @@
 import request from "../services/request"
 
 interface Aoml {
+    [key: string]: any | number,
     name: string;
     start: string;
     end: string;

--- a/webAO/utils/aoml.ts
+++ b/webAO/utils/aoml.ts
@@ -1,7 +1,7 @@
 import request from "../services/request"
 
 interface Aoml {
-    [key: string]: any | number,
+    [key: string]: string | number,
     name: string;
     start: string;
     end: string;


### PR DESCRIPTION
The main issue was that we weren't _reaaaallllyyy_ sure what the name of the property would be. We know that it was defined in the `Aoml` interface; however, typescript didn't trust that enough. 
```js
const contentKey = contentName.split('_')[1]
parsed[currentHeader][contentKey] = contentValue
```

By adding `[key: string]: string | number` it's a little risky because you can assign whatever value you want to an `Aoml` object; however, you're now allowing for the creation of the object dynamically. This shouldn't pose any problem because we only use specific properties attached to the Aoml object.