### PR TITLE
Fix music list display

### DIFF
--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -8,7 +8,7 @@ import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import { EventEmitter } from 'events';
 import tryUrls from './utils/tryUrls'
 import {
-  escapeChat, prepChat, safeTags,
+  escapeChat, prepChat, safeTags, unescapeChat,
 } from './encoding';
 import mlConfig from './utils/aoml';
 // Load some defaults for the background and evidence dropdowns
@@ -30,6 +30,7 @@ import getAnimLength from './utils/getAnimLength.js';
 import getResources from './utils/getResources.js';
 import transparentPng from './constants/transparentPng';
 import downloadFile from './services/downloadFile'
+import { getFilenameFromPath } from './utils/paths';
 const version = process.env.npm_package_version;
 
 let client: Client;
@@ -1180,7 +1181,9 @@ class Client extends EventEmitter {
 
   addTrack(trackname: string) {
     const newentry = <HTMLOptionElement>document.createElement('OPTION');
-    newentry.text = trackname;
+    const songName = getFilenameFromPath(trackname);
+    newentry.text = unescapeChat(songName);
+    newentry.value = trackname;
     (<HTMLSelectElement>document.getElementById('client_musiclist')).options.add(newentry);
     this.musics.push(trackname);
   }
@@ -1271,7 +1274,7 @@ class Client extends EventEmitter {
 
     for (let i = 1; i < args.length - 1; i++) {
       // Check when found the song for the first time
-      const trackname = safeTags(args[i]);
+      const trackname = args[i];
       const trackindex = i - 1;
       document.getElementById('client_loadingtext').innerHTML = `Loading Music ${i}/${this.music_list_length}`;
       (<HTMLProgressElement>document.getElementById('client_loadingbar')).value = this.char_list_length + this.evidence_list_length + i;

--- a/webAO/utils/__tests__/paths.test.ts
+++ b/webAO/utils/__tests__/paths.test.ts
@@ -1,0 +1,13 @@
+import {getFilenameFromPath} from '../paths'
+jest.mock('../fileExists')
+
+describe('getFilenameFromPath', () => {
+    const EXAMPLE_PATH = "localhost/stoneddiscord/assets.png"
+    it('Should get the last value from a path', async () => {
+        const actual = getFilenameFromPath(EXAMPLE_PATH);
+        const expected = 'assets.png';
+        expect(actual).toBe(expected);
+    });
+})
+
+  

--- a/webAO/utils/paths.ts
+++ b/webAO/utils/paths.ts
@@ -1,0 +1,1 @@
+export const getFilenameFromPath = (path: string) => path.substring(path.lastIndexOf('/') + 1)


### PR DESCRIPTION
Users were experiencing an issue where the full filepath existed for the music list. 
![image](https://user-images.githubusercontent.com/36182383/179152375-683f42cb-9177-4e79-a5f5-e8e2f1526ff8.png)

There also seemed to be another issue that this PR takes care of where the <and> wasn't being escaped properly on the repository. I noticed this only on the current master repo as it looks like this issue doesn't effect webtest or web. I've ensured that I had the matching `node` version based on the `.nvmrc` file to make sure it wasn't juts my development environment. Below is a screenshot of the example.
![image](https://user-images.githubusercontent.com/36182383/179152920-b33f5c3c-d421-403d-9ecb-8511fe36783f.png)


This pull request fixes both of these issues.
![image](https://user-images.githubusercontent.com/36182383/179152474-84e81fcf-62df-4ba7-b313-287e0ffbd7f6.png)

Unit tests for this PR are also 100% code coverage
![image](https://user-images.githubusercontent.com/36182383/179152973-c011b5f7-cd2a-4fa7-b7db-455cd060db7d.png)



The reasoning behind creating the paths file is a preemptive attempt to consolidate all of the path operations that the application may need. Considering we deal with multiple assets, I figure it's something we can utilize at a later date.