### PR TITLE
Focus input box when emotion is picked

### DIFF
--- a/webAO/dom/pickEmotion.ts
+++ b/webAO/dom/pickEmotion.ts
@@ -20,5 +20,7 @@ export function pickEmotion(emo: number) {
 
     (<HTMLInputElement>document.getElementById("sendpreanim")).checked =
         client.emote.zoom == 1;
+
+    (<HTMLInputElement>document.getElementById("client_inputbox")).focus();
 }
 window.pickEmotion = pickEmotion;


### PR DESCRIPTION
The most common action after picking an emotion is typing in IC, so it should make sense to focus it automatically on picked emotion.