### PR TITLE
Rework query param parsing and set window title to server name

### DIFF
--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -37,7 +37,7 @@ export const UPDATE_INTERVAL = 60;
  */
 export let oldLoading = false;
 export const setOldLoading = (val: boolean) => {
-    console.warn("old loading set to "+val)
+    console.warn("old loading set to " + val)
     oldLoading = val
 }
 
@@ -221,7 +221,7 @@ class Client extends EventEmitter {
         console.error(`The connection was closed: ${e.reason} (${e.code})`);
         if (extrafeatures.length == 0 && banned === false) {
             document.getElementById("client_errortext").textContent =
-        "Could not connect to the server";
+                "Could not connect to the server";
         }
         document.getElementById("client_waiting").style.display = "block";
         document.getElementById("client_error").style.display = "flex";
@@ -239,15 +239,14 @@ class Client extends EventEmitter {
         console.debug(`S: ${msg}`);
 
         this.handle_server_packet(msg);
-    
+
     }
 
     /**
    * Decode the packet
    * @param {MessageEvent} e
    */
-    handle_server_packet(p_data: string)
-    {
+    handle_server_packet(p_data: string) {
         let in_data = p_data;
 
         if (!p_data.endsWith("%")) {
@@ -284,8 +283,7 @@ class Client extends EventEmitter {
             }
             // Take the first arg as the command
             const command = f_contents[0];
-            if(command!=="")
-            {
+            if (command !== "") {
                 // The rest is contents of the packet
                 packetHandler.has(command)
                     ? packetHandler.get(command)(f_contents)

--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -17,7 +17,9 @@ import { loadResources } from './client/loadResources'
 import { AO_HOST } from './client/aoHost'
 import { fetchBackgroundList, fetchEvidenceList, fetchCharacterList } from './client/fetchLists'
 
-const { ip: serverIP, mode, theme } = queryParser();
+const { ip: serverIP, mode, theme, serverName } = queryParser();
+
+document.title = serverName;
 
 export let CHATBOX: string;
 export const setCHATBOX = (val: string) => {

--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -19,7 +19,6 @@ import { fetchBackgroundList, fetchEvidenceList, fetchCharacterList, fetchManife
 const version = process.env.npm_package_version;
 const { ip: serverIP, mode, theme } = queryParser();
 
-const THEME: string = theme || "default";
 export let CHATBOX: string;
 export const setCHATBOX = (val: string) => {
     CHATBOX = val
@@ -68,6 +67,11 @@ fpPromise
     .then((fp) => fp.get())
     .then((result) => {
         hdid = result.visitorId;
+
+        if (!serverIP) {
+            alert("No server IP specified!");
+            return;
+        }
 
         client = new Client(serverIP);
         client.connect()
@@ -146,7 +150,7 @@ class Client extends EventEmitter {
         this.musics_time = false;
         this.callwords = [];
         this.manifest = [];
-        this.resources = getResources(AO_HOST, THEME);
+        this.resources = getResources(AO_HOST, theme);
         this.selectedEmote = -1;
         this.selectedEvidence = 0;
         this.checkUpdater = null;

--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -15,8 +15,8 @@ import { onReplayGo } from './dom/onReplayGo'
 import { packetHandler } from './packets/packetHandler'
 import { loadResources } from './client/loadResources'
 import { AO_HOST } from './client/aoHost'
-import { fetchBackgroundList, fetchEvidenceList, fetchCharacterList, fetchManifest } from './client/fetchLists'
-const version = process.env.npm_package_version;
+import { fetchBackgroundList, fetchEvidenceList, fetchCharacterList } from './client/fetchLists'
+
 const { ip: serverIP, mode, theme } = queryParser();
 
 export let CHATBOX: string;

--- a/webAO/client/aoHost.ts
+++ b/webAO/client/aoHost.ts
@@ -1,7 +1,7 @@
 import queryParser from '../utils/queryParser'
+
 const { asset } = queryParser();
-const DEFAULT_HOST = 'http://attorneyoffline.de/base/';
-export let AO_HOST = asset || DEFAULT_HOST 
+export let AO_HOST = asset;
 export const setAOhost = (val: string) => {
-    AO_HOST = val
+    AO_HOST = val;
 }

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -137,12 +137,13 @@ function processServerlist(thelist: { name: string, description: string, ip: str
         servers[i].online = "Offline";
 
         const ipport = `${serverEntry.ip}:${serverEntry.ws_port}`;
+        const serverName = serverEntry.name;
 
         if (serverEntry.ws_port) {
             document.getElementById('masterlist').innerHTML
                 += `<li id="server${i}" onmouseover="setServ(${i})"><p>${safeTags(serverEntry.name)}</p>`
-                + `<a class="button" href="${myURL}client.html?mode=watch&ip=${ipport}">Watch</a>`
-                + `<a class="button" href="${myURL}client.html?mode=join&ip=${ipport}">Join</a></li>`;
+                + `<a class="button" href="${myURL}client.html?mode=watch&ip=${ipport}&serverName=${serverName}">Watch</a>`
+                + `<a class="button" href="${myURL}client.html?mode=join&ip=${ipport}&serverName=${serverName}">Join</a></li>`;
         }
     }
 }

--- a/webAO/utils/queryParser.ts
+++ b/webAO/utils/queryParser.ts
@@ -2,24 +2,19 @@
 
 interface QueryParams {
     ip: string;
-    serverIP: string;
     mode: string;
     asset: string;
     theme: string;
 }
 
-interface StringMap {
-    [key: string]: any;
-}
-
 const queryParser = (): QueryParams => {
-    const queryDict: StringMap = {};
-    location.search
-        .substr(1)
-        .split("&")
-        .forEach((item) => {
-            queryDict[item.split("=")[0]] = item.split("=")[1];
-        });
-    return queryDict as QueryParams;
+    const urlParams = new URLSearchParams(window.location.search);
+    const queryParams = {
+        ip: urlParams.get("ip") || "",
+        mode: urlParams.get("mode") || "join",
+        asset: urlParams.get("asset") || "http://attorneyoffline.de/base/",
+        theme: urlParams.get("theme") || "default",
+    }
+    return queryParams as QueryParams;
 };
 export default queryParser;

--- a/webAO/utils/queryParser.ts
+++ b/webAO/utils/queryParser.ts
@@ -5,6 +5,7 @@ interface QueryParams {
     mode: string;
     asset: string;
     theme: string;
+    serverName: string;
 }
 
 const queryParser = (): QueryParams => {
@@ -14,6 +15,7 @@ const queryParser = (): QueryParams => {
         mode: urlParams.get("mode") || "join",
         asset: urlParams.get("asset") || "http://attorneyoffline.de/base/",
         theme: urlParams.get("theme") || "default",
+        serverName: urlParams.get("serverName") || "Attorney Online session"
     }
     return queryParams as QueryParams;
 };


### PR DESCRIPTION
- Replace custom query param parsing with URLSearchParams, and move all defaults into that file
- add serverName to query params
- set window title to server name on joining
- add error checking on missing mandatory query param (server ip)
- formatting

In case of multiclienting in multiple tabs, this should be useful to keep track of which tab is connected to which server. If it hasn't been changed, the desktop client also does this. In the future, it might even make sense to add the area name to the window title as well.