### PR TITLE
Do not deploy on PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - master
-  pull_request:
-    branches:
-    - master
     
 jobs:
   build:


### PR DESCRIPTION
It looks like the workflows file tries to deploy to prod whenever a PR is opened that targets master. This doesn't look correct, and seems to fail with permissions issues when external collaborators open PRs (as it should).