### PR TITLE
fix URL in check_https

### DIFF
--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -76,8 +76,10 @@ fpPromise
 
 export function check_https() {
     if (protocol === 'https:') {
+        const newURL: string = window.location.href.replace('https:', 'http:');
         document.getElementById('https_error').style.display = '';
-        setTimeout(() => window.location.replace("http://web.aceattorneyonline.com/"), 5000);
+        console.log('HTTPS detected, redirecting to HTTP');
+        setTimeout(() => window.location.replace(newURL), 5000);
     }
 }
 


### PR DESCRIPTION
Hardcoding the URL doesn't work if the code is deployed elsewhere. window.location.href should contain the full URL