### PR TITLE
Fix https and add wss support

### DIFF
--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -17,7 +17,7 @@ import { loadResources } from './client/loadResources'
 import { AO_HOST } from './client/aoHost'
 import { fetchBackgroundList, fetchEvidenceList, fetchCharacterList } from './client/fetchLists'
 
-const { ip: serverIP, mode, theme, serverName } = queryParser();
+const { connect, mode, theme, serverName } = queryParser();
 
 document.title = serverName;
 
@@ -70,12 +70,12 @@ fpPromise
     .then((result) => {
         hdid = result.visitorId;
 
-        if (!serverIP) {
-            alert("No server IP specified!");
+        if (!connect) {
+            alert("No connection string specified!");
             return;
         }
 
-        client = new Client(serverIP);
+        client = new Client(connect);
         client.connect()
         isLowMemory();
         loadResources();
@@ -117,7 +117,7 @@ class Client extends EventEmitter {
     connect: () => void;
     loadResources: () => void
     isLowMemory: () => void
-    constructor(address: string) {
+    constructor(connectionString: string) {
         super();
 
         this.connect = () => {
@@ -126,7 +126,7 @@ class Client extends EventEmitter {
             this.on("message", this.onMessage.bind(this));
             this.on("error", this.onError.bind(this));
             if (mode !== "replay") {
-                this.serv = new WebSocket(`ws://${address}`);
+                this.serv = new WebSocket(connectionString);
                 // Assign the websocket events
                 this.serv.addEventListener("open", this.emit.bind(this, "open"));
                 this.serv.addEventListener("close", this.emit.bind(this, "close"));

--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -83,6 +83,13 @@ fpPromise
             }
         }
 
+        if (window.location.protocol === "https:" && connectionString.startsWith("ws://")) {
+            // If protocol is https: and connectionString is ws://
+            // We have a problem, since it's impossible to connect to ws:// from https://
+            // Connection will fail, but at least warn the user
+            alert('Attempted to connect using insecure websockets on https page. Please try removing s from https:// in the URL bar.')
+        }
+
         client = new Client(connectionString);
         client.connect()
         isLowMemory();

--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -17,7 +17,7 @@ import { loadResources } from './client/loadResources'
 import { AO_HOST } from './client/aoHost'
 import { fetchBackgroundList, fetchEvidenceList, fetchCharacterList } from './client/fetchLists'
 
-const { connect, mode, theme, serverName } = queryParser();
+const { ip: serverIP, connect, mode, theme, serverName } = queryParser();
 
 document.title = serverName;
 
@@ -70,12 +70,20 @@ fpPromise
     .then((result) => {
         hdid = result.visitorId;
 
-        if (!connect) {
-            alert("No connection string specified!");
-            return;
+        let connectionString = connect;
+
+        if (!connectionString) {
+            if (serverIP) {
+                // if connectionString is not set, try IP
+                // and just guess ws, though it could be wss
+                connectionString = `ws://${serverIP}`;
+            } else {
+                alert("No connection string specified!");
+                return;
+            }
         }
 
-        client = new Client(connect);
+        client = new Client(connectionString);
         client.connect()
         isLowMemory();
         loadResources();

--- a/webAO/client/aoHost.ts
+++ b/webAO/client/aoHost.ts
@@ -3,5 +3,14 @@ import queryParser from '../utils/queryParser'
 const { asset } = queryParser();
 export let AO_HOST = asset;
 export const setAOhost = (val: string) => {
+    const currentProtocol = window.location.protocol;
+    const assetProtocol = val.split(':')[0] + ':';
+
+    if (currentProtocol === 'https:' && assetProtocol === 'http:') {
+        // In this specific case, we need to request assets over HTTPS
+        console.log('Upgrading asset link to https');
+        val = val.replace('http:', 'https:');
+    }
+
     AO_HOST = val;
 }

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -139,7 +139,7 @@ function getCachedServerlist(): AOServer[] {
 
 function processServerlist(serverlist: AOServer[]) {
     const clientURL: string = `${protocol}//${host}/client.html`;
-    for (let i = 0; i < serverlist.length - 1; i++) {
+    for (let i = 0; i < serverlist.length; i++) {
         const server = serverlist[i];
         let port = 0;
         let protocol = '';

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -1,5 +1,11 @@
 import { safeTags } from './encoding';
 
+declare global {
+    interface Window {
+        setServ: (ID: number) => void;
+    }
+}
+
 interface AOServer {
     name: string,
     description: string,
@@ -55,6 +61,15 @@ function main() {
 }
 
 main();
+
+export function setServ(ID: number) {
+    console.log(`Setting server to ${ID}`);
+    const server = servers[ID];
+    const onlineStr = server.online;
+    const serverDesc = safeTags(server.description);
+    document.getElementById('serverdescription_content').innerHTML = `<b>${onlineStr}</b><br>${serverDesc})`;
+}
+window.setServ = setServ;
 
 
 // Fetches the serverlist from the masterserver
@@ -144,11 +159,11 @@ function processServerlist(serverlist: AOServer[]) {
 
         const connect = `${protocol}://${server.ip}:${port}`;
         const serverName = server.name;
-        server.online = 'Offline';
+        server.online = `Players: ${server.players}`;
         servers.push(server);
 
         document.getElementById('masterlist').innerHTML
-            += `<li id="server${i}"><p>${safeTags(server.name)} (${server.players})</p>`
+            += `<li id="server${i}" onmouseover="setServ(${i})"><p>${safeTags(server.name)} (${server.players})</p>`
             + `<a class="button" href="${clientURL}?mode=watch&connect=${connect}&serverName=${serverName}">Watch</a>`
             + `<a class="button" href="${clientURL}?mode=join&connect=${connect}&serverName=${serverName}">Join</a></li>`;
     }

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -143,29 +143,34 @@ function processServerlist(serverlist: AOServer[]) {
         let port = 0;
         let ws_protocol = '';
         let http_protocol = '';
-        let domain = '';
+        let client_subdomain = '';
 
         if (server.ws_port) {
             port = server.ws_port;
             ws_protocol = 'ws';
             http_protocol = 'http';
-            domain = 'insecure';
+            client_subdomain = 'insecure';
         }
         if (server.wss_port) {
             port = server.wss_port;
             ws_protocol = 'wss';
             http_protocol = 'https';
-            domain = 'web';
+            client_subdomain = 'web';
         }
+
         if (port === 0 || protocol === '') {
             console.warn(`Server ${server.name} has no websocket port, skipping`)
             continue;
         }
 
+        let hostname = window.location.hostname;
         // Replace the first element of the domain with the correct subdomain
         const domainElements = window.location.hostname.split('.');
-        domainElements[0] = domain;
-        let hostname = domainElements.join('.');
+        // If there is only one element, it's typically localhost or something, so don't replace it
+        if (domainElements.length >= 2) {
+            domainElements[0] = client_subdomain;
+            hostname = domainElements.join('.');
+        }
 
         if (window.location.port) {
             hostname += `:${window.location.port}`;

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -159,7 +159,7 @@ function processServerlist(serverlist: AOServer[]) {
             continue;
         }
 
-        const clientURL: string = `${http_protocol}//${host}/client.html`;
+        const clientURL: string = `${http_protocol}://${host}/client.html`;
         const connect = `${ws_protocol}://${server.ip}:${port}`;
         const serverName = server.name;
         server.online = `Players: ${server.players}`;

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -25,6 +25,7 @@ const clientVersion = process.env.npm_package_version;
 // const MASTERSERVER_IP = 'master.aceattorneyonline.com:27014';
 const serverlist_domain = 'servers.aceattorneyonline.com';
 const protocol = window.location.protocol;
+const host = window.location.host;
 
 const serverlist_cache_key = 'masterlist';
 
@@ -77,7 +78,7 @@ fpPromise
 export function check_https() {
     if (protocol === 'https:') {
         document.getElementById('https_error').style.display = '';
-        setTimeout(() => window.location.replace("http://web.aceattorneyonline.com/"), 5000);
+        setTimeout(() => window.location.replace(`http://${host}/`), 5000);
     }
 }
 
@@ -210,7 +211,6 @@ function getCachedServerlist(): AOServer[] {
 }
 
 function processServerlist(serverlist: AOServer[]) {
-    const host = window.location.host;
     const clientURL: string = `${protocol}//${host}/client.html`;
     for (let i = 0; i < serverlist.length - 1; i++) {
         const server = serverlist[i];

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -2,12 +2,6 @@ import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
 import { safeTags } from './encoding';
 
-declare global {
-    interface Window {
-        setServ: (ID: number) => void;
-    }
-}
-
 interface AOServer {
     name: string,
     description: string,
@@ -72,15 +66,6 @@ fpPromise
         // i don't need the ms to play alone
         setTimeout(() => checkOnline(-1, '127.0.0.1:50001'), 0);
     });
-
-export function setServ(ID: number) {
-    selectedServer = ID;
-
-    if (document.getElementById(`server${ID}`).className === '') { checkOnline(ID, `${servers[ID].ip}:${servers[ID].ws_port}`); }
-
-    document.getElementById('serverdescription_content').innerHTML = `<b>${servers[ID].online}</b><br>${safeTags(servers[ID].description)}`;
-}
-window.setServ = setServ;
 
 function checkOnline(serverID: number, coIP: string) {
     let serverConnection: WebSocket;
@@ -226,7 +211,7 @@ function processServerlist(serverlist: AOServer[]) {
         servers.push(server);
 
         document.getElementById('masterlist').innerHTML
-            += `<li id="server${i}" onmouseover="setServ(${i})"><p>${safeTags(server.name)} (${server.players})</p>`
+            += `<li id="server${i}"><p>${safeTags(server.name)} (${server.players})</p>`
             + `<a class="button" href="${clientURL}?mode=watch&connect=${connect}&serverName=${serverName}">Watch</a>`
             + `<a class="button" href="${clientURL}?mode=join&connect=${connect}&serverName=${serverName}">Join</a></li>`;
     }

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -143,23 +143,35 @@ function processServerlist(serverlist: AOServer[]) {
         let port = 0;
         let ws_protocol = '';
         let http_protocol = '';
+        let domain = '';
 
         if (server.ws_port) {
             port = server.ws_port;
             ws_protocol = 'ws';
             http_protocol = 'http';
+            domain = 'insecure';
         }
         if (server.wss_port) {
             port = server.wss_port;
             ws_protocol = 'wss';
             http_protocol = 'https';
+            domain = 'web';
         }
         if (port === 0 || protocol === '') {
             console.warn(`Server ${server.name} has no websocket port, skipping`)
             continue;
         }
 
-        const clientURL: string = `${http_protocol}://${host}/client.html`;
+        // Replace the first element of the domain with the correct subdomain
+        const domainElements = window.location.hostname.split('.');
+        domainElements[0] = domain;
+        let hostname = domainElements.join('.');
+
+        if (window.location.port) {
+            hostname += `:${window.location.port}`;
+        }
+
+        const clientURL: string = `${http_protocol}://${hostname}/client.html`;
         const connect = `${ws_protocol}://${server.ip}:${port}`;
         const serverName = server.name;
         server.online = `Players: ${server.players}`;

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -67,7 +67,7 @@ export function setServ(ID: number) {
     const server = servers[ID];
     const onlineStr = server.online;
     const serverDesc = safeTags(server.description);
-    document.getElementById('serverdescription_content').innerHTML = `<b>${onlineStr}</b><br>${serverDesc})`;
+    document.getElementById('serverdescription_content').innerHTML = `<b>${onlineStr}</b><br>${serverDesc}`;
 }
 window.setServ = setServ;
 

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -164,8 +164,8 @@ function processServerlist(serverlist: AOServer[]) {
 
         document.getElementById('masterlist').innerHTML
             += `<li id="server${i}" onmouseover="setServ(${i})"><p>${safeTags(server.name)} (${server.players})</p>`
-            + `<a class="button" href="${clientURL}?mode=watch&connect=${connect}&serverName=${serverName}">Watch</a>`
-            + `<a class="button" href="${clientURL}?mode=join&connect=${connect}&serverName=${serverName}">Join</a></li>`;
+            + `<a class="button" href="${clientURL}?mode=watch&connect=${connect}&serverName=${serverName}" target="_blank">Watch</a>`
+            + `<a class="button" href="${clientURL}?mode=join&connect=${connect}&serverName=${serverName}" target="_blank">Join</a></li>`;
     }
 }
 

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -153,6 +153,7 @@ function processServerlist(serverlist: AOServer[]) {
             protocol = 'wss';
         }
         if (port === 0 || protocol === '') {
+            console.warn(`Server ${server.name} has no websocket port, skipping`)
             continue;
         }
 

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -63,7 +63,6 @@ function main() {
 main();
 
 export function setServ(ID: number) {
-    console.log(`Setting server to ${ID}`);
     const server = servers[ID];
     const onlineStr = server.online;
     const serverDesc = safeTags(server.description);

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -59,8 +59,6 @@ fpPromise
     .then(async (result) => {
         hdid = result.visitorId;
 
-        check_https();
-
         getServerlist().then((serverlist) => {
             processServerlist(serverlist);
         });
@@ -74,13 +72,6 @@ fpPromise
         // i don't need the ms to play alone
         setTimeout(() => checkOnline(-1, '127.0.0.1:50001'), 0);
     });
-
-export function check_https() {
-    if (protocol === 'https:') {
-        document.getElementById('https_error').style.display = '';
-        setTimeout(() => window.location.replace(`http://${host}/`), 5000);
-    }
-}
 
 export function setServ(ID: number) {
     selectedServer = ID;

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -138,26 +138,29 @@ function getCachedServerlist(): AOServer[] {
 }
 
 function processServerlist(serverlist: AOServer[]) {
-    const clientURL: string = `${protocol}//${host}/client.html`;
     for (let i = 0; i < serverlist.length; i++) {
         const server = serverlist[i];
         let port = 0;
-        let protocol = '';
+        let ws_protocol = '';
+        let http_protocol = '';
 
         if (server.ws_port) {
             port = server.ws_port;
-            protocol = 'ws';
+            ws_protocol = 'ws';
+            http_protocol = 'http';
         }
         if (server.wss_port) {
             port = server.wss_port;
-            protocol = 'wss';
+            ws_protocol = 'wss';
+            http_protocol = 'https';
         }
         if (port === 0 || protocol === '') {
             console.warn(`Server ${server.name} has no websocket port, skipping`)
             continue;
         }
 
-        const connect = `${protocol}://${server.ip}:${port}`;
+        const clientURL: string = `${http_protocol}//${host}/client.html`;
+        const connect = `${ws_protocol}://${server.ip}:${port}`;
         const serverName = server.name;
         server.online = `Players: ${server.players}`;
         servers.push(server);

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -23,7 +23,6 @@ const clientVersion = process.env.npm_package_version;
 // const MASTERSERVER_IP = 'master.aceattorneyonline.com:27014';
 const serverlist_domain = 'servers.aceattorneyonline.com';
 const protocol = window.location.protocol;
-const host = window.location.host;
 
 const serverlist_cache_key = 'masterlist';
 

--- a/webAO/master.ts
+++ b/webAO/master.ts
@@ -215,26 +215,29 @@ function processServerlist(serverlist: AOServer[]) {
     for (let i = 0; i < serverlist.length - 1; i++) {
         const server = serverlist[i];
         let port = 0;
+        let protocol = '';
 
         if (server.ws_port) {
             port = server.ws_port;
+            protocol = 'ws';
         }
         if (server.wss_port) {
             port = server.wss_port;
+            protocol = 'wss';
         }
-        if (port === 0) {
+        if (port === 0 || protocol === '') {
             continue;
         }
 
-        const ipport = `${server.ip}:${port}`;
+        const connect = `${protocol}://${server.ip}:${port}`;
         const serverName = server.name;
         server.online = 'Offline';
         servers.push(server);
 
         document.getElementById('masterlist').innerHTML
             += `<li id="server${i}" onmouseover="setServ(${i})"><p>${safeTags(server.name)} (${server.players})</p>`
-            + `<a class="button" href="${clientURL}?mode=watch&ip=${ipport}&serverName=${serverName}">Watch</a>`
-            + `<a class="button" href="${clientURL}?mode=join&ip=${ipport}&serverName=${serverName}">Join</a></li>`;
+            + `<a class="button" href="${clientURL}?mode=watch&connect=${connect}&serverName=${serverName}">Watch</a>`
+            + `<a class="button" href="${clientURL}?mode=join&connect=${connect}&serverName=${serverName}">Join</a></li>`;
     }
 }
 

--- a/webAO/utils/queryParser.ts
+++ b/webAO/utils/queryParser.ts
@@ -10,12 +10,13 @@ interface QueryParams {
 }
 
 const queryParser = (): QueryParams => {
+    const protocol = window.location.protocol;
     const urlParams = new URLSearchParams(window.location.search);
     const queryParams = {
         ip: urlParams.get("ip") || "",
         connect: urlParams.get("connect") || "",
         mode: urlParams.get("mode") || "join",
-        asset: urlParams.get("asset") || "http://attorneyoffline.de/base/",
+        asset: urlParams.get("asset") || `${protocol}//attorneyoffline.de/base/`,
         theme: urlParams.get("theme") || "default",
         serverName: urlParams.get("serverName") || "Attorney Online session",
     }

--- a/webAO/utils/queryParser.ts
+++ b/webAO/utils/queryParser.ts
@@ -2,6 +2,7 @@
 
 interface QueryParams {
     ip: string;
+    connect: string;
     mode: string;
     asset: string;
     theme: string;
@@ -12,10 +13,11 @@ const queryParser = (): QueryParams => {
     const urlParams = new URLSearchParams(window.location.search);
     const queryParams = {
         ip: urlParams.get("ip") || "",
+        connect: urlParams.get("connect") || "",
         mode: urlParams.get("mode") || "join",
         asset: urlParams.get("asset") || "http://attorneyoffline.de/base/",
         theme: urlParams.get("theme") || "default",
-        serverName: urlParams.get("serverName") || "Attorney Online session"
+        serverName: urlParams.get("serverName") || "Attorney Online session",
     }
     return queryParams as QueryParams;
 };


### PR DESCRIPTION
This changes the way the serverlist works quite fundamentally. Notable points:

- All logic related to connecting to servers from index.html has been removed
- Renamed ip query param to connect, and make it a full connection string with protocol, host and port
- Hack a subdomain change when joining a ws-only server
- Asset links hopefully still work with https

The benefits is that the server list is more respectful of the user's privacy (no connection/giving away your IP on hovering) and it works with https (no more annoying warnings).

The drawbacks is that it requires configuring an "insecure" domain and that the client can't know if the server is reachable from the serverlist.

A proof of concept is live at https://web.troid.tech/ , it might require additional testing.