### PR TITLE
Some bugfixes (upscaling, preanimation, webp on char buttons, viewport layout)

### DIFF
--- a/webAO/packets/handlers/handlePV.ts
+++ b/webAO/packets/handlers/handlePV.ts
@@ -44,6 +44,20 @@ export const handlePV = async (args: string[]) => {
                 }
                 // Make sure the asset server is case insensitive, or that everything on it is lowercase
 
+                const extensionsMap = [".png", ".webp"];
+                let url;
+                for (const extension of extensionsMap) {
+                    url = `${AO_HOST}characters/${encodeURI(
+                        me.name.toLowerCase()
+                    )}/emotions/button${i}_off${extension}`;
+
+                    const exists = await fileExists(url);
+
+                    if (exists) {
+                        break;
+                    }
+                }
+
                 emotes[i] = {
                     desc: emoteinfo[0].toLowerCase(),
                     preanim: emoteinfo[1].toLowerCase(),
@@ -55,9 +69,7 @@ export const handlePV = async (args: string[]) => {
                     frame_screenshake: "",
                     frame_realization: "",
                     frame_sfx: "",
-                    button: `${AO_HOST}characters/${encodeURI(
-                        me.name.toLowerCase()
-                    )}/emotions/button${i}_off.png`,
+                    button: url,
                 };
 
                 const emote_item = new Image();

--- a/webAO/styles/client.css
+++ b/webAO/styles/client.css
@@ -206,9 +206,11 @@
 #client_court_static {
 	position: absolute;
 	height: 100%;
-	width: 100%;
 	top: 0;
 	left: 0;
+	top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 #client_court {
@@ -216,6 +218,9 @@
 	height: 100%;
 	top: 0;
 	left: 0;
+	top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 #client_stitch_court {
@@ -229,8 +234,10 @@
 #client_stitch_court>img {
 	position: absolute;
 	height: 100%;
-	width: 100%;
 	bottom: 0;
+	top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 #client_court_classic {
@@ -238,10 +245,13 @@
 	height: 100%;
 	top: 0;
 	left: 0;
+	top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 .def_court {
-	object-position: left;
+	object-position: center;
 }
 
 .wit_court {
@@ -249,7 +259,7 @@
 }
 
 .pro_court {
-	object-position: right;
+	object-position: center;
 }
 
 #client_fullview {
@@ -275,15 +285,19 @@
 	bottom: 0;
 }
 
+
 .client_char>img {
 	position: absolute;
 	height: 100%;
-	width: 100%;
 	bottom: 0;
 	left: 0;
-	object-fit: cover;
-	object-position: 50% 0;
+	top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
 }
+
+
 
 #client_bench_classic {
 	left: 0;
@@ -311,17 +325,20 @@
 
 .client_bench {
 	position: absolute;
-	height: auto;
-	width: 100%;
+	height: 100%;
+	width: 1;
 	bottom: 0;
+	object-fit: contain;
 }
 
 #client_fg {
 	position: absolute;
 	height: 100%;
-	width: 100%;
 	bottom: 0;
 	left: 0;
+	top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 #client_evi {

--- a/webAO/styles/client.css
+++ b/webAO/styles/client.css
@@ -279,7 +279,6 @@
 	position: absolute;
 	height: 100%;
 	bottom: 0;
-	left: 0;
 	top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);

--- a/webAO/styles/client.css
+++ b/webAO/styles/client.css
@@ -206,11 +206,9 @@
 #client_court_static {
 	position: absolute;
 	height: 100%;
+	width: 100%;
 	top: 0;
 	left: 0;
-	top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
 }
 
 #client_court {
@@ -218,9 +216,6 @@
 	height: 100%;
 	top: 0;
 	left: 0;
-	top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
 }
 
 #client_stitch_court {
@@ -234,10 +229,8 @@
 #client_stitch_court>img {
 	position: absolute;
 	height: 100%;
+	width: 100%;
 	bottom: 0;
-	top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
 }
 
 #client_court_classic {
@@ -245,9 +238,6 @@
 	height: 100%;
 	top: 0;
 	left: 0;
-	top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
 }
 
 .def_court {
@@ -285,7 +275,6 @@
 	bottom: 0;
 }
 
-
 .client_char>img {
 	position: absolute;
 	height: 100%;
@@ -296,8 +285,6 @@
     transform: translate(-50%, -50%);
 
 }
-
-
 
 #client_bench_classic {
 	left: 0;
@@ -326,7 +313,6 @@
 .client_bench {
 	position: absolute;
 	height: 100%;
-	width: 1;
 	bottom: 0;
 	object-fit: contain;
 }

--- a/webAO/styles/default.css
+++ b/webAO/styles/default.css
@@ -2,10 +2,24 @@ body {
 	font-family: sans-serif;
 }
 
+@media (max-height: 270x) {
+	img {
+		image-rendering: crisp-edges;
+		image-rendering: pixelated;
+	}
+
+}
+
 img {
+	image-rendering: auto;
+}
+
+img[src$=".gif"],
+img[src$=".apng"] {
 	image-rendering: crisp-edges;
 	image-rendering: pixelated;
 }
+
 
 .client_button {
 	margin: 1px;

--- a/webAO/viewport/viewport.ts
+++ b/webAO/viewport/viewport.ts
@@ -234,9 +234,6 @@ const viewport = (): Viewport => {
     // note: this is called fairly often
     // do not perform heavy operations here
     await delay(chatmsg.speed);
-    if (textnow === chatmsg.content) {
-      return;
-    }
 
     const gamewindow = document.getElementById("client_gamewindow");
     const waitingBox = document.getElementById("client_chatwaiting");
@@ -443,6 +440,9 @@ const viewport = (): Viewport => {
           chatmsg.looping_sfx
         );
       }
+    }
+    if (textnow === chatmsg.content) {
+      return;
     }
     if (animating) {
       chat_tick();


### PR DESCRIPTION
## This fixes:

- #191 
- #92 (Partially fixed)

## Changes:
- Now every image, except the desk (which needs work done), is centered on the X and Y axis in the viewport. This makes it more similar to how AO 2.8+ manages the viewport by default.
- **Adds support for webp buttons:** This was the only place that didn't have **webp** support.
- **Better upscaling/downscaling detection.** It applies pixelated/fast to every **gif** and **apng**, while the **png** and **webp** have the smooth filter.


Current state:
Stable