### PR TITLE
Add connect timeout

### DIFF
--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -337,6 +337,7 @@ class Client extends EventEmitter {
     onError(e: ErrorEvent) {
         client.state = clientState.NotConnected;
         console.error(`A network error occurred`);
+        console.error(e);
         document.getElementById("client_error").style.display = "flex";
         this.cleanup();
     }

--- a/webAO/client.ts
+++ b/webAO/client.ts
@@ -157,6 +157,14 @@ class Client extends EventEmitter {
                 this.serv.addEventListener("close", this.emit.bind(this, "close"));
                 this.serv.addEventListener("message", this.emit.bind(this, "message"));
                 this.serv.addEventListener("error", this.emit.bind(this, "error"));
+
+                // If the client is still not connected 5 seconds after attempting to join
+                // It's fair to assume that the server is not reachable
+                setTimeout(() => {
+                    if (this.state === clientState.NotConnected) {
+                        this.serv.close();
+                    }
+                }, 5000);
             } else {
                 this.joinServer();
             }

--- a/webAO/packets/handlers/handleDONE.ts
+++ b/webAO/packets/handlers/handleDONE.ts
@@ -1,4 +1,5 @@
 import queryParser from "../../utils/queryParser";
+import { client, clientState } from "../../client";
 
 const { mode } = queryParser()
 /**
@@ -8,9 +9,11 @@ const { mode } = queryParser()
    * @param {Array} args packet arguments
    */
 export const handleDONE = (_args: string[]) => {
-    document.getElementById("client_loading")!.style.display = "none";
-    if (mode === "watch") {
-      // Spectators don't need to pick a character
-      document.getElementById("client_waiting")!.style.display = "none";
-    }
+  // DONE packet signals that the handshake is complete
+  client.state = clientState.Joined;
+  document.getElementById("client_loading")!.style.display = "none";
+  if (mode === "watch") {
+    // Spectators don't need to pick a character
+    document.getElementById("client_waiting")!.style.display = "none";
+  }
 }


### PR DESCRIPTION
If the server is not reachable from client.ts, the current default timeout is very long. I think it's fair to assume that if the client hasn't managed to connect within 5 seconds, it's a lost cause. This change also adds a clientState enum, which might be helpful to make good decisions based on which state the client is in.