### PR TITLE
Dependabot configuration to update actions in workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Look for GitHub Actions workflows in the `root` directory
+    directory: "/"
+    # Check the for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Noticed the actions used in https://github.com/AttorneyOnline/webAO/tree/master/.github/workflows are outdated, proposing a Dependabot configuration to update - reference https://docs.github.com/en/actions/security-guides/using-githubs-security-features-to-secure-your-use-of-github-actions#keeping-the-actions-in-your-workflows-secure-and-up-to-date

Resolves warning on executions ex. https://github.com/AttorneyOnline/webAO/actions/runs/10752533651
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v1

Suggest enabling https://docs.github.com/en/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners#enabling-or-disabling-for-your-repository as well