### PR TITLE
Fix Additive

### DIFF
--- a/webAO/packets/handlers/handleMS.ts
+++ b/webAO/packets/handlers/handleMS.ts
@@ -4,16 +4,14 @@ import { client, extrafeatures, UPDATE_INTERVAL } from "../../client";
 import { handleCharacterInfo } from "../../client/handleCharacterInfo";
 import { resetICParams } from "../../client/resetICParams";
 import { prepChat, safeTags } from "../../encoding";
-import { handle_ic_speaking } from '../../viewport/utils/handleICSpeaking'
+import { handle_ic_speaking } from "../../viewport/utils/handleICSpeaking";
 /**
-   * Handles an in-character chat message.
-   * @param {*} args packet arguments
-   */
+ * Handles an in-character chat message.
+ * @param {*} args packet arguments
+ */
 export const handleMS = (args: string[]) => {
   // TODO: this if-statement might be a bug.
   if (args[4] !== client.viewport.getChatmsg().content) {
-    document.getElementById("client_inner_chat")!.innerHTML = "";
-
     const char_id = Number(args[9]);
     const char_name = safeTags(args[3]);
 

--- a/webAO/viewport/utils/handleICSpeaking.ts
+++ b/webAO/viewport/utils/handleICSpeaking.ts
@@ -78,7 +78,9 @@ export const handle_ic_speaking = async (playerChatMsg: ChatMsg) => {
             : client.viewport.getChatmsg().nameplate!;
 
     // Clear out the last message
-    chatBoxInner.innerText = client.viewport.getTextNow();
+    if (!client.viewport.getChatmsg().additive) {
+        chatBoxInner.innerText = client.viewport.getTextNow();
+    }
     nameBoxInner.innerText = displayname;
 
     if (client.viewport.getLastCharacter() !== client.viewport.getChatmsg().name) {


### PR DESCRIPTION
Resolves #209 

When a user submits a message and it's additive, it shouldn't clear out the text box.

Originally when a user would submit a message and it was getting parsed, this would reset the message. To keep a separation of concerns, the parsing shouldn't have any impact on the UI until the parsed message is handled. 


https://github.com/user-attachments/assets/8d4567db-34bf-4421-a1de-05d96e0e55fb



