### PR TITLE
Remove the gap between IC and emotes

### DIFF
--- a/webAO/ui.js
+++ b/webAO/ui.js
@@ -18,7 +18,6 @@ const config = {
       width: 40,
       content: [{
         type: 'component',
-        height: 80,
         isClosable: false,
         componentName: 'template',
         title: 'IC',
@@ -26,7 +25,7 @@ const config = {
       },
       {
         type: 'component',
-        height: 20,
+        height: 50,
         isClosable: false,
         title: 'IC Options',
         componentName: 'template',


### PR DESCRIPTION
There was a large gap on initial visiting of the page. Fixed it to minify the gap.

If you've altered the sizing, be sure to clear out your cookies to reset goldenlayout back to initial sizing.

## Before
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/b5e6f763-9b42-4f40-899f-7a72df1da190">

## After
<img width="924" alt="image" src="https://github.com/user-attachments/assets/dbe6d24a-5941-4b6a-b566-ec67c64d58ac">
