### PR TITLE
IC: treat empty preanim string as no preanim

### DIFF
--- a/webAO/viewport/utils/handleICSpeaking.ts
+++ b/webAO/viewport/utils/handleICSpeaking.ts
@@ -168,7 +168,8 @@ export const handle_ic_speaking = async (playerChatMsg: ChatMsg) => {
 
   if (
     client.viewport.getChatmsg().type === 1 &&
-    client.viewport.getChatmsg().preanim !== "-"
+    client.viewport.getChatmsg().preanim !== "-" &&
+    client.viewport.getChatmsg().preanim !== ""
   ) {
     //we have a preanim
     chatContainerBox.style.opacity = "0";


### PR DESCRIPTION
When an emote is defined with empty preanimation string, such as EmoteName##emote#, and a user selects "Preanim," WebAO tries to look up a file with an empty name instead of disabling preanimation. This commit fixes this, matching AO2 client behavior and not requiring character makers to put a magic "-" preanimation in char.ini.